### PR TITLE
Efficient piece selection

### DIFF
--- a/src/extensions/magnet_links/metadata_piece_manager.rs
+++ b/src/extensions/magnet_links/metadata_piece_manager.rs
@@ -60,7 +60,6 @@ impl MetadataPieceManager {
         else {
             return Ok(None);
         };
-        dbg!(piece_index);
         self.queue[piece_index] = BlockState::InProcess;
         let msg = MetadataMsg {
             msg_type: MetadataMsgType::Request,

--- a/src/extensions/magnet_links/metadata_piece_manager.rs
+++ b/src/extensions/magnet_links/metadata_piece_manager.rs
@@ -45,11 +45,15 @@ impl MetadataPieceManager {
             .iter()
             .position(|i_have| *i_have == BlockState::None)
             .or_else(|| {
-                self.queue
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(index, i_have)| (*i_have == BlockState::InProcess).then(|| index))
-                    .choose(&mut rand::rng())
+                self.check_finished().then(|| {
+                    self.queue
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, i_have)| {
+                            (*i_have == BlockState::InProcess).then(|| index)
+                        })
+                        .choose(&mut rand::rng())
+                })?
             })
         // Note that one peer will not get the same request twice since it won't ask for another if it's waiting for the response of one.
         // If it got the response, it won't get the piece again anyways.

--- a/src/extensions/protocol_extension_handshake.rs
+++ b/src/extensions/protocol_extension_handshake.rs
@@ -29,7 +29,7 @@ pub(crate) struct AdditionalHandshakeInfo {
     /// A string containing the compact representation of the ip address this peer sees you
     pub(crate) yourip: Option<YourIp>,
     /// An integer, the number of outstanding request messages this client supports without dropping any.
-    pub(crate) reqq: Option<usize>,
+    pub(crate) reqq: Option<u32>,
 }
 
 impl HandshakeExtension {

--- a/src/messages/payloads.rs
+++ b/src/messages/payloads.rs
@@ -23,8 +23,13 @@ impl BitfieldPayload {
     pub(crate) fn is_finished(&self) -> bool {
         self.pieces_available.iter().all(|b| *b)
     }
+    // so the motivation here was to get the correct size of the bitfield payload since it might be too long
+    // however we have the number of pieces only in the metadata which we might not have yet
     pub(crate) fn get_correct_len(self, n_pieces: usize) -> Vec<bool> {
         self.pieces_available.into_iter().take(n_pieces).collect()
+    }
+    pub(crate) fn get_pieces(self) -> Vec<bool> {
+        self.pieces_available
     }
 }
 impl Payload for BitfieldPayload {

--- a/src/messages/payloads.rs
+++ b/src/messages/payloads.rs
@@ -9,14 +9,22 @@ pub trait Payload {
 #[derive(Debug, Clone, PartialEq)]
 pub struct BitfieldPayload {
     /// a bitfield with each index that downloader has sent set to one and the rest set to zero
-    pub(crate) pieces_available: Vec<bool>,
+    pieces_available: Vec<bool>,
 }
 impl BitfieldPayload {
+    pub(crate) fn new(bitfield: impl IntoIterator<Item = bool>) -> Self {
+        Self {
+            pieces_available: bitfield.into_iter().collect(),
+        }
+    }
     pub(crate) fn is_empty(&self) -> bool {
         self.pieces_available.iter().all(|b| !*b)
     }
     pub(crate) fn is_finished(&self) -> bool {
         self.pieces_available.iter().all(|b| *b)
+    }
+    pub(crate) fn get_correct_len(self, n_pieces: usize) -> Vec<bool> {
+        self.pieces_available.into_iter().take(n_pieces).collect()
     }
 }
 impl Payload for BitfieldPayload {

--- a/src/peer/conn.rs
+++ b/src/peer/conn.rs
@@ -5,6 +5,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU32;
 use std::time::Duration;
 
 use futures_core::Stream;
@@ -22,6 +23,7 @@ use tokio_util::time::FutureExt;
 
 use crate::extensions::ExtensionHandler;
 use crate::messages::{MessageFramer, PeerMessage};
+use crate::peer::DEFAULT_MAX_REQUESTS;
 use crate::peer::Msg;
 use crate::peer::Peer;
 use crate::peer::error::PeerError;
@@ -138,6 +140,7 @@ pub(crate) struct PeerStateInner {
     pub(crate) am_interested: AtomicBool,
     pub(crate) peer_choking: AtomicBool,
     pub(crate) peer_interested: AtomicBool,
+    pub(crate) max_req: AtomicU32,
     /// maps extended message ID to names of extensions
     /// TODO: we definetly don't need this here
     pub(crate) extensions: Mutex<Option<HashMap<u8, Box<dyn ExtensionHandler>>>>,
@@ -157,6 +160,7 @@ impl PeerState {
             peer_choking: AtomicBool::new(true),
             peer_interested: AtomicBool::new(false),
             extensions: Mutex::new(extensions),
+            max_req: AtomicU32::new(DEFAULT_MAX_REQUESTS),
         };
         Self(Arc::new(peer_identifier_inner))
     }

--- a/src/peer/conn.rs
+++ b/src/peer/conn.rs
@@ -138,9 +138,8 @@ pub(crate) struct PeerStateInner {
     pub(crate) am_interested: AtomicBool,
     pub(crate) peer_choking: AtomicBool,
     pub(crate) peer_interested: AtomicBool,
-    /// the bitfield of the other peer
-    pub(crate) has: Mutex<Vec<bool>>,
     /// maps extended message ID to names of extensions
+    /// TODO: we definetly don't need this here
     pub(crate) extensions: Mutex<Option<HashMap<u8, Box<dyn ExtensionHandler>>>>,
 }
 
@@ -157,7 +156,6 @@ impl PeerState {
             am_interested: AtomicBool::new(false),
             peer_choking: AtomicBool::new(true),
             peer_interested: AtomicBool::new(false),
-            has: Mutex::new(Vec::new()),
             extensions: Mutex::new(extensions),
         };
         Self(Arc::new(peer_identifier_inner))

--- a/src/peer/event_loop.rs
+++ b/src/peer/event_loop.rs
@@ -111,6 +111,7 @@ impl Peer {
                         PeerMessage::Unchoke(_no_payload) => {
                             eprintln!("PEER UNCHOKES");
                             self.state.0.peer_choking.store(false, Ordering::Relaxed);
+                            self.send_peer(PeerMessage::Unchoke(NoPayload)).await?;
                         }
                         PeerMessage::Interested(_no_payload) => {
                             self.state.0.peer_interested.store(true, Ordering::Relaxed);

--- a/src/peer/event_loop.rs
+++ b/src/peer/event_loop.rs
@@ -120,11 +120,12 @@ impl Peer {
                             self.state.0.peer_interested.store(false, Ordering::Relaxed);
                         }
                         PeerMessage::Have(have_payload) => {
-                            self.state.0.has.lock().unwrap()[have_payload.piece_index as usize] =
-                                true;
+                            self.send_peer_manager(ReqMessage::PeerHas(have_payload))
+                                .await?;
                         }
                         PeerMessage::Bitfield(bitfield_payload) => {
-                            *self.state.0.has.lock().unwrap() = bitfield_payload.pieces_available;
+                            self.send_peer_manager(ReqMessage::PeerBitfield(bitfield_payload))
+                                .await?;
                         }
                         PeerMessage::Request(request_piece_payload) => {
                             self.send_peer_manager(ReqMessage::NeedBlock(request_piece_payload))

--- a/src/peer/mod.rs
+++ b/src/peer/mod.rs
@@ -11,6 +11,8 @@ use crate::peer::conn::{BoxedMsgStream, PeerState};
 use crate::peer::error::PeerError;
 use crate::peer_manager::{ReqMessage, ReqMsgFromPeer, ResMessage};
 
+pub const DEFAULT_MAX_REQUESTS: u32 = 100;
+
 pub mod conn;
 mod error;
 mod event_loop;

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -21,6 +21,8 @@ use crate::{
 pub mod error;
 mod piece_manager;
 
+type PeerId = [u8; 20];
+
 pub const BLOCK_QUEUE_SIZE_MAX: usize = 20;
 /// how many pieces are in the queue at max
 pub(crate) const MAX_PIECES_IN_PARALLEL: usize = 5;
@@ -30,7 +32,7 @@ pub struct PeerManager {
     torrent_state: TorrentState,
     rx: mpsc::Receiver<ReqMsgFromPeer>,
     announce_urls: Vec<url::Url>,
-    peers: HashMap<[u8; 20], PeerConn>,
+    peers: HashMap<PeerId, PeerConn>,
 }
 
 #[derive(Debug)]

--- a/src/peer_manager/piece_manager/mod.rs
+++ b/src/peer_manager/piece_manager/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     },
 };
 mod file_manager;
+mod piece_selector;
 mod req_preparer;
 
 #[derive(Debug)]

--- a/src/peer_manager/piece_manager/piece_selector.rs
+++ b/src/peer_manager/piece_manager/piece_selector.rs
@@ -142,13 +142,13 @@ impl PieceSelector {
     // - (if yes) is the piece even up-to-date
     // - (if yes) does the peer even have that piece
     // - (if yes) is the piece already requested by any peer
-    /// selects `count` amount of pieces from a peer so he can request them
+    /// selects `count` amount of pieces from a peer so we can request them
     pub(super) fn select_pieces_for_peer(&mut self, id: &PeerId, count: usize) -> Option<Vec<u32>> {
         let Some(bitfield) = self.peer_bitfields.get(id) else {
             return None;
         };
         let mut queue = Vec::with_capacity(count);
-        while queue.len() <= queue.capacity()
+        while queue.len() <= count
             && let Some(Reverse((count, piece_i))) = self.priority_queue.pop()
         {
             let i = piece_i as usize;
@@ -187,7 +187,9 @@ impl PieceSelector {
     }
 
     pub(in crate::peer_manager) fn get_peer_has(&self, id: &PeerId) -> Option<&Vec<bool>> {
-        self.peer_bitfields.get(id)
+        self.peer_bitfields
+            .get(id)
+            .and_then(|b| (!b.is_empty()).then(|| b))
     }
 
     pub(in crate::peer_manager) fn get_have(&self) -> &Vec<bool> {

--- a/src/peer_manager/piece_manager/piece_selector.rs
+++ b/src/peer_manager/piece_manager/piece_selector.rs
@@ -1,0 +1,145 @@
+//! This whole thing is merely existent for selecting the next pieces we might send to peers.
+//! The actual job of creating requests, handling timeouts is done in the `req_preparer.rs`
+
+use std::{
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap},
+    vec,
+};
+
+use crate::peer_manager::PeerId;
+
+// 1.  We **keep** the `piece_rarity: Vec<u32>` as the single source of truth for piece rarity.
+// 2.  When a piece's rarity is updated (e.g., a peer connects and has the piece), we simply **push a new entry** `(new_rarity, piece_index)` into the `BinaryHeap`. We do **not** remove the old entry.
+// 3.  When we call `select_pieces_for_peer`, we pop an item (rarity_in_heap, piece_index)` from the heap.
+// 4.  **Crucially, we then check if `rarity_in_heap` matches the current, true rarity in `self.piece_rarity[piece_index]`.**
+//     *   If they don't match, it means this heap entry is **stale**. We discard it and pop the next one.
+//     *   If they match, this is a valid, up-to-date entry. We process it.
+
+// This "lazy" approach has some great benefits:
+// *   **Correctness:** We only ever act on the most up-to-date rarity information.
+// *   **Simplicity:** We only use the standard library's `BinaryHeap` and a `Vec`. No complex data structures needed.
+// *   **Good Performance:** The heap might grow larger with stale entries, but heap operations are logarithmic (`log N`). In practice, the performance is excellent, and the stale entries are cleaned out as they are encountered. The cost of pushing a new entry is small.
+#[derive(Debug)]
+pub(in crate::peer_manager) struct PieceSelector {
+    /// A vector where the index is the piece index and the value
+    /// is the number of peers that have this piece.
+    piece_rarity: Vec<u32>,
+
+    /// A priority queue of pieces to download.
+    /// The tuple is (rarity, piece_index).
+    // (a,b)>(c,d) if a>c OR (a=c AND b>d) which makes this work as it should
+    priority_queue: BinaryHeap<Reverse<(u32, u32)>>,
+
+    /// Our own bitfield, to know which pieces we already have.
+    pub(super) have: Vec<bool>,
+
+    /// A map to store the bitfield for each peer.
+    /// The key is the PeerId.
+    peer_bitfields: HashMap<PeerId, Vec<bool>>,
+
+    /// Tracks pieces that are currently in the DownloadQueue.
+    /// This prevents us from selecting the same piece multiple times.
+    /// A Vec<bool> is likely more efficient than a HashSet<u32> if piece indices are contiguous.
+    pieces_in_flight: Vec<bool>,
+}
+
+impl PieceSelector {
+    pub(in crate::peer_manager) fn new(have: Vec<bool>) -> Self {
+        let n_piceces = have.len();
+        Self {
+            piece_rarity: vec![0; n_piceces],
+            priority_queue: BinaryHeap::with_capacity(n_piceces),
+            have,
+            peer_bitfields: HashMap::new(),
+            pieces_in_flight: vec![false; n_piceces],
+        }
+    }
+
+    pub(in crate::peer_manager) fn add_peer(&mut self, id: PeerId) {
+        if let Some(old) = self.peer_bitfields.insert(id, Vec::new()) {
+            // this shouldn't happen, but if it does we're safe
+            self.peer_bitfields.insert(id, old);
+        };
+    }
+
+    /// removes the peer from the list and the priority queue
+    pub(in crate::peer_manager) fn remove_peer(&mut self, id: &PeerId) {
+        if let Some(bitfield) = self.peer_bitfields.remove(id) {
+            self.update_prio_queue(bitfield, false);
+        }
+    }
+
+    /// updates the priority queue if the peer sent us his bitfield
+    /// if the piece is not added via `add_peer` yet, it will do nothing
+    pub(in crate::peer_manager) fn add_bitfield(&mut self, id: &PeerId, bitfield: Vec<bool>) {
+        if let Some(peer_bitfield) = self.peer_bitfields.get_mut(id) {
+            *peer_bitfield = bitfield.clone();
+            self.update_prio_queue(bitfield, true);
+        }
+    }
+
+    /// updates the priority queue if the peer sent us a have message
+    pub(in crate::peer_manager) fn update_have(&mut self, id: &PeerId, have_index: u32) {
+        // for easier indexing
+        let i = have_index as usize;
+        if let Some(peer_bitfield) = self.peer_bitfields.get_mut(id)
+            && let Some(b_peer) = peer_bitfield.get_mut(i)
+            && let Some(rarity) = self.piece_rarity.get_mut(i)
+        {
+            *b_peer = true;
+            *rarity += 1;
+            if !self.have[i] {
+                self.priority_queue.push(Reverse((*rarity, have_index)));
+            }
+        }
+    }
+
+    // checks in order:
+    // - (does bitfield for peer exist)
+    // - is there a next piece from the priority queue
+    // - (if yes) is the piece even up-to-date
+    // - (if yes) does the peer even have that piece
+    // - (if yes) is the piece already requested by any peer
+    /// selects `count` amount of pieces from a peer so he can request them
+    pub(super) fn select_pieces_for_peer(&mut self, id: &PeerId, count: usize) -> Option<Vec<u32>> {
+        let Some(bitfield) = self.peer_bitfields.get(id) else {
+            return None;
+        };
+        let mut queue = Vec::with_capacity(count);
+        while queue.len() <= queue.capacity()
+            && let Some(Reverse((count, piece_i))) = self.priority_queue.pop()
+        {
+            let i = piece_i as usize;
+            // the priority queue doesn't have to be up to date since we don't remove values if we receive e.g. a have message
+            if self.piece_rarity[i] == count && bitfield[i] && !self.pieces_in_flight[i] {
+                queue.push(piece_i);
+                self.pieces_in_flight[i] = true;
+            }
+        }
+        if queue.is_empty() { None } else { Some(queue) }
+    }
+
+    /// updates both priority queues with a bitfield and whether it should increase or decrease the count
+    fn update_prio_queue(&mut self, bitfield: impl IntoIterator<Item = bool>, increase: bool) {
+        self.piece_rarity
+            .iter_mut()
+            .enumerate()
+            .zip(bitfield)
+            .zip(&self.have)
+            .for_each(|(((i, count), b_p), b_i)| {
+                if b_p && !b_i {
+                    match increase {
+                        true => *count += 1,
+                        false => *count = count.saturating_sub(1),
+                    }
+                    self.priority_queue.push(Reverse((*count, i as u32)));
+                }
+            });
+        dbg!(&self.priority_queue);
+    }
+
+    pub(in crate::peer_manager) fn get_peer_has(&self, id: &PeerId) -> Option<&Vec<bool>> {
+        self.peer_bitfields.get(id)
+    }
+}

--- a/src/peer_manager/piece_manager/req_preparer.rs
+++ b/src/peer_manager/piece_manager/req_preparer.rs
@@ -4,89 +4,39 @@ use rand::seq::IteratorRandom;
 use crate::{
     BLOCK_MAX,
     messages::payloads::RequestPiecePayload,
-    peer_manager::{BlockState, MAX_PIECES_IN_PARALLEL, PieceManager, PieceState},
+    peer_manager::{BlockState, MAX_PIECES_IN_PARALLEL, PeerId, PieceManager, PieceState},
     torrent::Metainfo,
 };
 
 #[derive(Debug)]
-pub(super) struct DownloadQueue(pub(in crate::peer_manager::piece_manager) Vec<PieceState>);
-
-impl DownloadQueue {
-    pub(super) fn new() -> Self {
-        Self(Vec::with_capacity(MAX_PIECES_IN_PARALLEL))
-    }
-
-    fn get_queue_for_peer(
-        &mut self,
-        i_have: &[bool],
-        peer_has: &[bool],
-        metainfo: &Metainfo,
-    ) -> Option<&mut PieceState> {
-        // 1. Try if we have something in the download queue
-        let piece_i = self.0.iter().position(|state| {
-            let peer_has_it = peer_has[state.piece_i as usize];
-            let blocks_we_need = state.blocks.iter().filter(|b| b.is_none());
-            // TODO: now currently if there's only one block remaining in the queue, it will return only that one
-            // we might want to return that plus like 9 more of the next piece
-            peer_has_it && blocks_we_need.count() >= 1
-        });
-
-        // 2. If not, add something to the queue: realistically rarest-first
-        if piece_i.is_none() && !self.add_piece_to_queue(i_have, peer_has, metainfo) {
-            return None;
-        }
-
-        let piece_i = piece_i.unwrap_or_else(|| self.0.len() - 1);
-        // the download_queue will have a last piece, because it may have been added by self.add_piece_to_queue. If it hasn't, we have returned.
-        Some(self.0.get_mut(piece_i).expect("we checked that before"))
-    }
-
-    /// checks whether the queue is full, if not adds a new item
-    /// returns whether a new piece is added (true) or not (false)
-    pub(in crate::peer_manager) fn add_piece_to_queue(
-        &mut self,
-        i_have: &[bool],
-        peer_has: &[bool],
-        metainfo: &Metainfo,
-    ) -> bool {
-        // if the queue is already to big but we're at the last piece, we still want to add it
-        if self.0.len() == MAX_PIECES_IN_PARALLEL && i_have.iter().filter(|b| **b).count() > 1 {
-            return false;
-        }
-
-        let Some(piece_i)= i_have
-            .iter()
-            .zip(peer_has)
-            .enumerate()
-            .filter_map(|(index, (i_have, p_has))| {
-                if !*i_have && *p_has /* Now theoretically we would check if the piece is already in the queue aswell but since we checked that before calling this function I don't do it here again */{
-                    Some(index as u32)
-                } else {
-                    None
-                }
-            }).choose(&mut rand::rng()) else { return false };
-
-        let piece_state = PieceState::new(metainfo, piece_i);
-        self.0.push(piece_state);
-
-        true
-    }
-}
+pub(super) struct DownloadQueue(pub(super) Vec<PieceState>);
 
 impl PieceManager {
     /// returns a list of blocks that we want to request
     pub(in crate::peer_manager) fn prepare_next_blocks(
         &mut self,
         n: usize,
-        peer_has: &[bool],
+        peer_id: &PeerId,
         metainfo: &Metainfo,
-    ) -> Vec<RequestPiecePayload> {
-        let Some(piece) = self
-            .download_queue
-            .get_queue_for_peer(&self.have, peer_has, metainfo)
-        else {
-            return vec![];
-        };
+    ) -> Option<Vec<RequestPiecePayload>> {
+        let piece = if let Some(peer_has) = self.piece_selector.get_peer_has(peer_id) {
+            if let Some(piece) = self.download_queue.get_queue_for_peer(peer_has) {
+                Some(piece)
+            } else {
+                // a bit awkard tbh
+                let peer_has = peer_has.clone();
+
+                if let Some(queue) = self
+                    .piece_selector
+                    .select_pieces_for_peer(peer_id, 3 /* TODO */)
+                {
+                    self.download_queue.add_pieces_to_queue(queue, metainfo);
+                }
+                self.download_queue.get_queue_for_peer(&peer_has)
+            }
+        } else {
+            None
+        }?;
 
         let mut requests = Vec::with_capacity(n);
         let n_blocks = piece.blocks.capacity() as u32;
@@ -109,7 +59,46 @@ impl PieceManager {
             *block = BlockState::InProcess;
         }
 
-        requests
+        Some(requests)
+    }
+}
+
+impl DownloadQueue {
+    pub(super) fn new() -> Self {
+        Self(Vec::with_capacity(MAX_PIECES_IN_PARALLEL))
+    }
+
+    fn get_queue_for_peer(&mut self, peer_has: &[bool]) -> Option<&mut PieceState> {
+        // 1. Try if we have something in the download queue
+        let piece_i = self.0.iter().position(|state| {
+            let Some(peer_has_it) = peer_has.get(state.piece_i as usize) else {
+                // I've had an occurrence where this failed
+                dbg!("WOAHUFHAKFLA:SFUIOHAF:IUHA:FIUAFIUB");
+                return false;
+            };
+            let blocks_we_need = state.blocks.iter().filter(|b| b.is_none());
+            // TODO: now currently if there's only one block remaining in the queue, it will return only that one
+            // we might want to return that plus like 9 more of the next piece
+            *peer_has_it && blocks_we_need.count() >= 1
+        })?;
+        // TODO: if we didn't find the piece here, we'll run the piece_selector and call this function again
+        // however it has to recompute the pieces so we might want to find a better solution here
+
+        // the download_queue will have a last piece, because it may have been added by self.add_piece_to_queue. If it hasn't, we have returned.
+        Some(self.0.get_mut(piece_i).expect("we checked that before"))
+    }
+
+    /// checks whether the queue is full, if not adds a new item
+    /// returns whether a new piece is added (true) or not (false)
+    pub(in crate::peer_manager) fn add_pieces_to_queue(
+        &mut self,
+        pieces: Vec<u32>,
+        metainfo: &Metainfo,
+    ) {
+        for piece_i in pieces.into_iter() {
+            let piece_state = PieceState::new(metainfo, piece_i);
+            self.0.push(piece_state);
+        }
     }
 }
 

--- a/todo.md
+++ b/todo.md
@@ -1,129 +1,19 @@
-# Codebase Analysis: Confusing File Structure and Improvement Hints
+- remove `have` and `extensions` from the `PeerStateInner`
+- rather have the peer the extensions
+- the `PeerManager` inits a `PieceSelector`
+- implement missing `ReqMessage` msgs: `GotHave(u32)`, `GotBitfield(Vec<bool>)`
+- if a bitfield or a have message is sent, tell the PeerManager
+  - he then calls the appropiate method for the piece_selector
 
-## Overview of Current `src/` Structure
+---
 
-The `src/` directory contains the core logic of the Bittorrent client. It's organized into several modules, with some top-level files and subdirectories for related functionalities.
+This is the most critical part. Here is how the `prepare_next_blocks` function for a specific peer (`Peer A`) should work:
 
-```
-src/
-├── .DS_Store
-├── client.rs
-├── database.rs
-├── extensions/
-│   ├── factory.rs
-│   ├── handshake.rs
-│   ├── mod.rs
-│   └── magnet_links/
-│       ├── metadata_piece_manager.rs
-│       ├── metadata_requester.rs
-│       └── mod.rs
-├── lib.rs
-├── main.rs
-├── messages/
-│   ├── client_identifier.rs
-│   ├── mod.rs
-│   └── payloads.rs
-├── peer/
-│   ├── conn.rs
-│   ├── error.rs
-│   ├── event_loop.rs
-│   ├── extensions.rs
-│   ├── handshake.rs
-│   └── mod.rs
-├── peer_manager/
-│   ├── error.rs
-│   ├── mod.rs
-│   └── piece_manager/
-│       ├── file_manager.rs
-│       ├── mod.rs
-│       └── req_preparer.rs
-├── torrent.rs
-└── tracker.rs
-```
+1. **Fill the `DownloadQueue`:** The `PieceManager` first checks if the central `DownloadQueue` is full. If not, it asks the `PieceSelector` for the best new pieces to add (that aren't already in the queue or `in_flight`) and adds their `PieceState`s to the `DownloadQueue`.
+2. **Iterate and Match:** The `prepare_next_blocks` function then iterates through every `PieceState` in the central `DownloadQueue`.
+3. **Check Peer Availability:** For each piece in the queue, it asks a crucial question: **"Does `Peer A` have this piece?"** This check is done by querying the `PieceSelector`, which stores all the peer bitfields.
+4. **Find Available Blocks:**
 
-## Identified Confusing Aspects
-
-1.  **`client.rs` being entirely commented out:** The `client.rs` file is completely commented out, yet it defines a `Client` struct and methods like `download_torrent` and `download_magnet`. This suggests that a `Client` abstraction was intended but is currently unused and possibly superseded by logic in `main.rs`. This creates confusion about the intended entry point and overall architecture.
-
-2.  **Duplication of logic in `main.rs` and `client.rs`:** The `main.rs` file contains significant logic for `Download` and `DownloadMagnet` commands that closely mirrors the commented-out `start_download` logic in `client.rs`. This indicates a lack of clear separation of concerns and potential code duplication.
-
-3.  **`lib.rs` as a re-export hub:** `lib.rs` primarily re-exports modules and specific structs/enums. While this is a common pattern, the `BittorrentClient` struct defined within `lib.rs` seems to be an incomplete or unused abstraction, further adding to the confusion about the core client structure.
-
-4.  **`extensions` module structure:** The `extensions` module contains `factory.rs`, `handshake.rs`, and `magnet_links/`. The `magnet_links` subdirectory itself contains `metadata_piece_manager.rs` and `metadata_requester.rs`. This nesting and the generic names like `factory.rs` and `handshake.rs` (which also appears in `peer/`) make it hard to immediately grasp their specific roles and how they relate to the overall system.
-
-5.  **`peer/` and `peer_manager/` overlap:** Both `peer/` and `peer_manager/` modules deal with peer-related logic. `peer/` contains `conn.rs`, `event_loop.rs`, `handshake.rs`, and `extensions.rs`, while `peer_manager/` contains `piece_manager/` with `file_manager.rs` and `req_preparer.rs`. The distinction between what belongs to a single `Peer` and what belongs to the `PeerManager` (which manages multiple peers) could be clearer, especially with `handshake.rs` appearing in both `peer/` and `extensions/`.
-
-6.  **`database.rs` dependency on `Torrent` and `Metainfo`:** `database.rs` directly imports `Torrent` and `Metainfo` from the top-level `crate`. While functional, it might be more robust if `database.rs` dealt with more generic data structures or if `Torrent` and `Metainfo` were part of a more central `core` or `data` module.
-
-7.  **Unused `BittorrentClient` struct in `lib.rs`:** The `BittorrentClient` struct in `lib.rs` is defined with `torrents` and `peer_manager` fields, but it doesn't appear to be used anywhere in the provided code snippets. This suggests an abandoned or incomplete architectural component.
-
-8.  **Commented-out code:** There's a significant amount of commented-out code, especially in `client.rs` and `main.rs` (e.g., `DownloadPiece` command). This makes it harder to understand the current active logic and what parts are still under development or have been deprecated.
-
-## Hints for Improvement
-
-### 1. Re-evaluate and Consolidate Client Logic
-
-*   **Action:** Decide on a single, clear entry point for client-side operations. Either fully implement and use the `Client` struct in `client.rs` or remove it and consolidate its responsibilities into `main.rs` or a new `application.rs` module.
-*   **Hint:** If `Client` is intended to be the main orchestrator, move the `download_torrent` and `download_magnet` logic from `main.rs` into the `Client` implementation. `main.rs` should then primarily parse CLI arguments and instantiate/call methods on the `Client`.
-
-### 2. Clarify Module Responsibilities
-
-*   **Action:** Define clear boundaries for each module (`peer`, `peer_manager`, `extensions`, `messages`).
-*   **Hint:**
-    *   **`peer/`**: Should focus solely on the state and behavior of a *single* peer connection (e.g., sending/receiving messages, managing its bitfield, handshake logic specific to a single connection).
-    *   **`peer_manager/`**: Should manage a collection of `Peer` instances, orchestrate piece downloading, handle overall download state, and interact with the `database`. The `piece_manager` subdirectory seems appropriate here.
-    *   **`extensions/`**: Should contain logic for specific Bittorrent protocol extensions. The `magnet_links` subdirectory is a good start. The `handshake.rs` in `extensions/` might be for a generic extension handshake, while `peer/handshake.rs` is for the initial peer handshake. If so, rename to clarify (e.g., `extensions/extension_handshake.rs`).
-    *   **`messages/`**: Already seems well-defined for protocol messages.
-
-### 3. Address Code Duplication
-
-*   **Action:** Refactor the duplicated download logic found in `main.rs` (for `Download` and `DownloadMagnet` commands) and the commented-out `client.rs`.
-*   **Hint:** Extract common download orchestration logic into a shared function or a method of the `Client` struct (if re-enabled). This will make the code more maintainable and easier to understand.
-
-### 4. Organize `extensions` Module
-
-*   **Action:** Review the `extensions` module and its subdirectories.
-*   **Hint:**
-    *   Ensure `factory.rs` has a clear purpose and is not overly generic. If it's a factory for extensions, its name is fine, but its contents should reflect that.
-    *   Clarify the role of `extensions/handshake.rs` versus `peer/handshake.rs`. If they serve different purposes, consider renaming for clarity (e.g., `peer/initial_handshake.rs` and `extensions/protocol_extension_handshake.rs`).
-
-### 5. Integrate `BittorrentClient` or Remove It
-
-*   **Action:** Decide whether the `BittorrentClient` struct in `lib.rs` is a necessary abstraction.
-*   **Hint:** If it's intended to be the high-level interface for the entire application, then `main.rs` should use it, and the `Client` struct in `client.rs` might become an internal component or be merged. If it's not needed, remove it to reduce confusion.
-
-### 6. Clean Up Commented-Out Code
-
-*   **Action:** Remove all commented-out code that is no longer relevant or actively being worked on.
-*   **Hint:** Use version control (Git) to track historical changes. Commented-out code clutters the codebase and makes it harder to read.
-
-### 7. Improve `database.rs` Dependencies
-
-*   **Action:** Consider if `database.rs` should have direct knowledge of `Torrent` and `Metainfo`.
-*   **Hint:** If `Torrent` and `Metainfo` are core data structures, they could reside in a `core` or `data` module, and `database.rs` would then depend on that core module. This creates a clearer dependency flow.
-
-### 8. Use Mermaid Diagrams for Complex Interactions
-
-*   **Action:** For complex interactions, such as the flow between `Client`, `PeerManager`, and `Peer`, consider adding Mermaid diagrams to `todo.md` or other documentation.
-
-Here's a high-level diagram of a potential improved structure:
-
-```mermaid
-graph TD
-    A[main.rs] --> B(Cli Parsing)
-    B --> C{Command Type}
-    C -- Download/DownloadMagnet --> D[Application/Client]
-    D --> E[Torrent Module]
-    D --> F[Tracker Module]
-    D --> G[PeerManager Module]
-    G --> H[Peer Module]
-    G --> I[Database Module]
-    H --> J[Messages Module]
-    H --> K[Extensions Module]
-```
-
-This diagram illustrates a more centralized `Application` or `Client` module orchestrating the main components.
-
-## Next Steps
-
-I've completed the analysis and created this `todo.md` file. Please review it and let me know if you'd like any changes or have further questions.
+   * If `Peer A` *does not* have the piece, we simply skip it and move to the next piece in the queue.
+   * If `Peer A` *does* have the piece, we then scan that piece's `blocks` vector to find a block that is in the `BlockState::None` state.
+5. **Generate Request:** If an available block is found, we generate a `RequestPiecePayload` for it, add it to our list of requests for `Peer A`, and immediately update that block's state to `BlockState::InProcess(timestamp)`.


### PR DESCRIPTION
This update make the selection and requesting of blocks much faster and rarest-first selection. I did not measure performance but I would say 100x faster. To do this, I have a separate PieceSelector which looks at all the pieces and sorts them by rarity. If a peer now want a queue, we'll first look into the queue if there's something: _if yes_ we get the next [count] amount of blocks (where [count] is the `reqq` header in the Handshake extension the peer sent us). _if no_ we ask the piece selector which fills the queue with pieces, the peer has and we don't.