### PR TITLE
Efficient piece selection

### DIFF
--- a/src/extensions/magnet_links/metadata_piece_manager.rs
+++ b/src/extensions/magnet_links/metadata_piece_manager.rs
@@ -53,7 +53,7 @@ impl MetadataPieceManager {
                         .iter()
                         .enumerate()
                         .filter_map(|(index, i_have)| {
-                            (matches!(i_have, BlockState::InProcess(t) if t.elapsed() >= TIMEOUT_METADATA_REQ)).then(|| index)
+                            (matches!(i_have, BlockState::InProcess(_))).then(|| index)
                         })
                         .choose(&mut rand::rng())
                 })?

--- a/src/extensions/magnet_links/metadata_piece_manager.rs
+++ b/src/extensions/magnet_links/metadata_piece_manager.rs
@@ -1,5 +1,7 @@
 //! This is all for the PeerManager
 
+use std::time::Duration;
+
 use bytes::{Bytes, BytesMut};
 use rand::seq::IteratorRandom;
 use sha1::{Digest, Sha1};
@@ -12,6 +14,7 @@ use crate::{
 
 /// The metadata is handled in blocks of 16KiB (16384 Bytes).
 const METADATA_BLOCK_SIZE: usize = 1 << 14;
+const TIMEOUT_METADATA_REQ: Duration = Duration::from_secs(5);
 
 #[derive(Debug)]
 pub(crate) struct MetadataPieceManager {
@@ -50,7 +53,7 @@ impl MetadataPieceManager {
                         .iter()
                         .enumerate()
                         .filter_map(|(index, i_have)| {
-                            (*i_have == BlockState::InProcess).then(|| index)
+                            (matches!(i_have, BlockState::InProcess(t) if t.elapsed() >= TIMEOUT_METADATA_REQ)).then(|| index)
                         })
                         .choose(&mut rand::rng())
                 })?
@@ -60,7 +63,7 @@ impl MetadataPieceManager {
         else {
             return Ok(None);
         };
-        self.queue[piece_index] = BlockState::InProcess;
+        self.queue[piece_index] = BlockState::InProcess(std::time::Instant::now());
         let msg = MetadataMsg {
             msg_type: MetadataMsgType::Request,
             piece_index: piece_index as u32,
@@ -175,7 +178,7 @@ mod tests {
         assert_eq!(msg_0.msg_type, MetadataMsgType::Request);
         assert_eq!(msg_0.piece_index, 0);
         assert_eq!(msg_0.total_size, None);
-        assert_eq!(manager.queue[0], BlockState::InProcess);
+        assert!(matches!(manager.queue[0], BlockState::InProcess(_)));
 
         // Request second block
         let req_data_1 = manager.get_block_req_data().unwrap().unwrap();

--- a/src/peer/conn.rs
+++ b/src/peer/conn.rs
@@ -99,7 +99,7 @@ async fn get_stream(
                 None
             }
             Ok(Some(Err(e))) => {
-                panic!("Error occured on PeerReader: {e:?}")
+                panic!("Error occurred on PeerReader: {e:?}")
             }
         }
     });
@@ -146,7 +146,7 @@ pub(crate) struct PeerStateInner {
     pub(crate) peer_interested: AtomicBool,
     pub(crate) max_req: AtomicU32,
     /// maps extended message ID to names of extensions
-    /// TODO: we definetly don't need this here
+    /// TODO: we definitely don't need this here
     pub(crate) extensions: Mutex<Option<HashMap<u8, Box<dyn ExtensionHandler>>>>,
 }
 

--- a/src/peer/conn.rs
+++ b/src/peer/conn.rs
@@ -34,6 +34,9 @@ use crate::peer_manager::ReqMsgFromPeer;
 use crate::peer_manager::ResMessage;
 use crate::torrent::InfoHash;
 
+const CHANNEL_SIZE: usize = 16;
+const KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(60);
+
 impl Peer {
     pub async fn connect_from_addr(
         addr: SocketAddrV4,
@@ -87,11 +90,12 @@ async fn get_stream(
     peer_manager_rx: Receiver<ResMessage>,
 ) -> BoxedMsgStream {
     let peer_msg_stream = unfold(framed_rx, |mut framed| async move {
-        match framed.next().timeout(Duration::from_secs(120)).await {
+        match framed.next().timeout(KEEPALIVE_TIMEOUT).await {
             Ok(Some(Ok(message))) => Some((Msg::Data(message), framed)),
             Err(_) => Some((Msg::Timeout, framed)),
             Ok(None) => {
                 // nothing really happens here
+                // we haven't received all the data yet
                 None
             }
             Ok(Some(Err(e))) => {
@@ -169,7 +173,7 @@ impl PeerState {
         &self,
         peer_manager_tx: &Sender<ReqMsgFromPeer>,
     ) -> Result<Receiver<ResMessage>, PeerError> {
-        let (sender, peer_manager_rx) = mpsc::channel(16);
+        let (sender, peer_manager_rx) = mpsc::channel(CHANNEL_SIZE);
         let peer_conn = PeerConn {
             sender,
             identifier: self.clone(),

--- a/src/peer_manager/piece_manager/piece_selector.rs
+++ b/src/peer_manager/piece_manager/piece_selector.rs
@@ -173,9 +173,8 @@ impl PieceSelector {
         self.piece_rarity
             .iter_mut()
             .enumerate()
-            .zip(bitfield)
-            .zip(&self.have)
-            .for_each(|(((i, count), b_p), b_i)| {
+            .zip(bitfield.into_iter().zip(&self.have))
+            .for_each(|((i, count), (b_p, b_i))| {
                 if b_p && !b_i {
                     match increase {
                         true => *count += 1,

--- a/src/peer_manager/piece_manager/req_preparer.rs
+++ b/src/peer_manager/piece_manager/req_preparer.rs
@@ -114,7 +114,7 @@ impl PieceState {
                 let begin = block_i * BLOCK_MAX;
                 let length = get_block_len(n_blocks, piece_size, block_i);
 
-                *block = BlockState::InProcess;
+                *block = BlockState::InProcess(std::time::Instant::now());
                 RequestPiecePayload::new(index, begin, length)
             })
             .collect()

--- a/src/peer_manager/piece_manager/req_preparer.rs
+++ b/src/peer_manager/piece_manager/req_preparer.rs
@@ -58,12 +58,10 @@ impl DownloadQueue {
         // 1. Try if we have something in the download queue
         let piece_i = self.0.iter().position(|state| {
             let Some(peer_has_it) = peer_has.get(state.piece_i as usize) else {
-                // we shouldn't be here at all
+                // this happens if a peer has not yet sent his bitfield which makes it empty
                 return false;
             };
             let blocks_we_need = state.blocks.iter().filter(|b| b.is_not_requested());
-            // TODO: now currently if there's only one block remaining in the queue, it will return only that one
-            // we might want to return that plus like 9 more of the next piece
             *peer_has_it && blocks_we_need.count() >= 1
         })?;
         // TODO: if we didn't find the piece here, we'll run the piece_selector and call this function again


### PR DESCRIPTION
Implemented a basic timeout for pieces so that they are getting re-requested if they haven't been received for a certain time, as well as removed a bug that caused peers to get disconnected. Will probably not implement Endgame in the near future.